### PR TITLE
Mark app as mobile-friendly for Flathub

### DIFF
--- a/data/io.github.revisto.drum-machine.metainfo.xml.in
+++ b/data/io.github.revisto.drum-machine.metainfo.xml.in
@@ -85,6 +85,7 @@
     <control>touch</control>
   </supports>
   <requires>
+    <display_length compare="ge">360</display_length>
     <internet>offline-only</internet>
   </requires>
   <content_rating type="oars-1.1" />


### PR DESCRIPTION
# Description

Adds metadata necessary to appear in Flathub's mobile/On the go collection:
https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#desktop-and-mobile-apps

# Type of Change

- [x] Documentation update

# Additional Notes

Related to https://github.com/Revisto/drum-machine/pull/6

