### PR TITLE
Update POTFILES.in

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -5,3 +5,4 @@ src/window.py
 src/window.ui
 src/gtk/help-overlay.ui
 src/gtk/save_changes_dialog.ui
+src/handlers/file_dialog_handler.py


### PR DESCRIPTION
# Description

Adds Add src/handlers/file_dialog_handler.py to POTFILES.in making it a source of translation string for xgettext.

# Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

# Additional Notes

`intltool-update -m` helped reporting this missing file in POTFILES.in