### PR TITLE
I add mute volume shortcut to drum machine issu #42

### DIFF
--- a/src/handlers/window_actions.py
+++ b/src/handlers/window_actions.py
@@ -48,6 +48,7 @@ class WindowActionHandler:
             ("go_to_instrument", self.handle_go_to_instrument_action, ["<primary>i"]),
             ("previous_page", self.handle_previous_page_action, ["Page_Up"]),
             ("next_page", self.handle_next_page_action, ["Page_Down"]),
+            ("mute_volume", self.handle_mute_volume,["<primary>m"]),
         ]
 
         for action_name, callback, shortcuts in actions:
@@ -138,3 +139,10 @@ class WindowActionHandler:
             n_pages = carousel.get_n_pages()
             if current_page < n_pages - 1:
                 carousel.scroll_to(carousel.get_nth_page(current_page + 1), True)
+    def handle_mute_volume(self, action, param):
+        current_volume = self.window.volume_button.get_value()
+        if current_volume != 0:
+            self.window.volume_button.set_value(0)
+        else:
+            self.window.volume_button.set_value(50)
+


### PR DESCRIPTION
# Description
I add new shortcut to this gnome application and compilet issu #42 
my changes :  
add <primary>m  into setup_actions function and connect to handle_mute_volume in end of this file for mute volume feature .

# Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

# Additional Notes

How does handle_mute_volume function work?

this function activate on press <primary>m on user keyboard and check current volume . If it was greater than zero set new volume to 0 ,But if it wasn't set new volume to 50 

I would be very happy if you would merge this changes 😍🙏

