### PR TITLE
Fix translation context issues for better translator experience

### DIFF
--- a/po/drum-machine.pot
+++ b/po/drum-machine.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: drum-machine\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-08 13:04+0330\n"
+"POT-Creation-Date: 2025-08-11 20:13+0330\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -181,7 +181,7 @@ msgstr ""
 msgid "Refined app icon, and adjusted brand colors for better contrast."
 msgstr ""
 
-#: src/application.py:68
+#: src/application.py:69
 msgid "translator-credits"
 msgstr ""
 
@@ -207,7 +207,12 @@ msgstr ""
 msgid "Open"
 msgstr ""
 
-#: src/window.ui:52 src/window.ui:55
+#: src/window.ui:52
+msgid "Open Preset"
+msgstr ""
+
+#: src/window.ui:55
+msgctxt "accessibility"
 msgid "Open Preset"
 msgstr ""
 
@@ -215,7 +220,12 @@ msgstr ""
 msgid "Open Saved Drum Pattern Preset"
 msgstr ""
 
-#: src/window.ui:74 src/window.ui:76
+#: src/window.ui:74
+msgid "Main Menu"
+msgstr ""
+
+#: src/window.ui:76
+msgctxt "accessibility"
 msgid "Main Menu"
 msgstr ""
 
@@ -223,7 +233,12 @@ msgstr ""
 msgid "Access Keyboard Shortcuts and Application Information"
 msgstr ""
 
-#: src/window.ui:84 src/window.ui:86
+#: src/window.ui:84
+msgid "Save Drum Pattern"
+msgstr ""
+
+#: src/window.ui:86
+msgctxt "accessibility"
 msgid "Save Drum Pattern"
 msgstr ""
 

--- a/src/window.ui
+++ b/src/window.ui
@@ -52,7 +52,7 @@ half-view</setter>
                 <property name="tooltip-text" translatable="yes">Open Preset</property>
                 <property name="menu-model">preset_menu</property>
                 <accessibility>
-                  <property name="label" translatable="yes">Open Preset</property>
+                  <property name="label" translatable="yes" context="accessibility">Open Preset</property>
                   <property name="description" translatable="yes">Open Saved Drum Pattern Preset</property>
                 </accessibility>
               </object>
@@ -73,7 +73,7 @@ half-view</setter>
                 <property name="menu-model">primary_menu</property>
                 <property name="tooltip-text" translatable="yes">Main Menu</property>
                 <accessibility>
-                  <property name="label" translatable="yes">Main Menu</property>
+                  <property name="label" translatable="yes" context="accessibility">Main Menu</property>
                   <property name="description" translatable="yes">Access Keyboard Shortcuts and Application Information</property>
                 </accessibility>
               </object>
@@ -83,7 +83,7 @@ half-view</setter>
                 <property name="icon-name">document-save-symbolic</property>
                 <property name="tooltip-text" translatable="yes">Save Drum Pattern</property>
                 <accessibility>
-                  <property name="label" translatable="yes">Save Drum Pattern</property>
+                  <property name="label" translatable="yes" context="accessibility">Save Drum Pattern</property>
                   <property name="description" translatable="yes">Save Current Drum Pattern as a Preset File</property>
                 </accessibility>
               </object>


### PR DESCRIPTION
# Description

Fixes translation context issues where identical strings in different contexts (tooltips vs accessibility labels) were extracted as single translation entries. Added `context="accessibility"` to accessibility labels in `window.ui` for "Open Preset", "Main Menu", and "Save Drum Pattern".

This allows translators to provide different translations for tooltips vs screen reader labels.

# Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

# Additional Notes

Fixes #43