### PR TITLE
Change gnome runtime version to 48

### DIFF
--- a/io.github.revisto.drum-machine.json
+++ b/io.github.revisto.drum-machine.json
@@ -1,7 +1,7 @@
 {
     "id" : "io.github.revisto.drum-machine",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "master",
+    "runtime-version" : "48",
     "sdk" : "org.gnome.Sdk",
     "command" : "drum-machine",
     "finish-args" : [


### PR DESCRIPTION
# Description

Fixes the GNOME runtime missing error in GNOME Builder.

<img width="538" height="274" alt="image" src="https://github.com/user-attachments/assets/f92380b9-f550-46fb-bdde-10695d304a08" />

# Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

# Additional Notes

Include any additional information that is important to this pull request.
