### PR TITLE
Fix crash sound playback issue by increasing audio channels

### DIFF
--- a/src/services/sound_service.py
+++ b/src/services/sound_service.py
@@ -26,6 +26,7 @@ from ..config.constants import DRUM_PARTS
 class SoundService(ISoundService):
     def __init__(self, drumkit_dir):
         pygame.init()
+        pygame.mixer.set_num_channels(32)
         self.drumkit_dir = drumkit_dir
         self.sounds = {}
 


### PR DESCRIPTION
# Description

Increase pygame mixer channels from the default to 32 to prevent audio channel exhaustion when multiple sounds play simultaneously.

Fixes #69

# Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
