### PR TITLE
Drop categories and keywords from metainfo file

### DIFF
--- a/data/io.github.revisto.drum-machine.desktop.in
+++ b/data/io.github.revisto.drum-machine.desktop.in
@@ -5,5 +5,7 @@ Icon=io.github.revisto.drum-machine
 Terminal=false
 Type=Application
 Categories=AudioVideo;Audio;Music;
+# Translators: Search terms to find this application. Do NOT translate or localise the semicolons! The list MUST also end with a semicolon!
+Keywords=drum;drums;sequencer;rhythm;music;pattern;beats;percussion;loop;groove;
 StartupNotify=true
 X-Purism-FormFactor=Workstation;Mobile;

--- a/data/io.github.revisto.drum-machine.metainfo.xml.in
+++ b/data/io.github.revisto.drum-machine.metainfo.xml.in
@@ -38,20 +38,6 @@
           <image>https://github.com/revisto/drum-machine/raw/master/data/screenshots/drum-machine-dark.png</image>
       </screenshot>
   </screenshots>
-  <categories>
-    <category>Audio</category>
-    <category>Music</category>
-    <category>GNOME</category>
-    <category>GTK</category>
-  </categories>
-  <keywords>
-    <keyword>drum</keyword>
-    <keyword>machine</keyword>
-    <keyword>rhythm</keyword>
-    <keyword>music</keyword>
-    <keyword>pattern</keyword>
-    <keyword>beats</keyword>
-  </keywords>
   <translation type="gettext">drum-machine</translation>
   <launchable type="desktop-id">io.github.revisto.drum-machine.desktop</launchable>
   <url type="homepage">https://github.com/revisto/drum-machine</url>


### PR DESCRIPTION
> If there’s a launchable defined for a desktop application, categories and keywords are pulled from the desktop file. Defining them separately in the Metainfo file will override the contents of the desktop file.
>
> Please don't use, generic categories like GTK, Qt, KDE, GNOME, Motif, Java, GUI, Application, XFCE, DDE as these are filtered by Appstream. These can be placed in Keywords if necessary. Please see the Menu specification for a list of valid category names.


More info: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#categories-and-keywords

# Description

Please include a summary of the changes and the related issue. Also include relevant motivation and context. Use "Fixes #<issue_number>" if applicable.

# Type of Change

- [x] Chores

# Additional Notes

Include any additional information that is important to this pull request.
