### PR TITLE
 Remove additional description from export page and change export icon

### DIFF
--- a/src/gtk/audio-export-dialog.ui
+++ b/src/gtk/audio-export-dialog.ui
@@ -37,12 +37,9 @@
                     <property name="margin-end">24</property>
                     <child>
                       <object class="AdwPreferencesGroup" id="export_group">
-                        <property name="title" translatable="yes">Export Settings</property>
-                        <property name="description" translatable="yes">Configure your audio export options</property>
                         <child>
                           <object class="AdwComboRow" id="format_row">
                             <property name="title" translatable="yes">Audio Format</property>
-                            <property name="subtitle" translatable="yes">Select the output audio format</property>
                             <property name="model">
                               <object class="GtkStringList" id="format_list">
                           </object>
@@ -69,7 +66,6 @@
                     <child>
                       <object class="AdwPreferencesGroup" id="metadata_group">
                         <property name="title" translatable="yes">Metadata</property>
-                        <property name="description" translatable="yes">Add metadata to your exported audio</property>
                         <child>
                           <object class="AdwEntryRow" id="artist_row">
                             <property name="title" translatable="yes">Artist Name</property>
@@ -85,7 +81,6 @@
                         <child>
                           <object class="AdwActionRow" id="cover_row">
                             <property name="title" translatable="yes">Cover Art</property>
-                            <property name="subtitle" translatable="yes">Select an image file for the cover art</property>
                             <property name="activatable-widget">cover_button</property>
                             <child>
                               <object class="GtkButton" id="cover_button">

--- a/src/window.ui
+++ b/src/window.ui
@@ -82,7 +82,7 @@ half-view</setter>
                 </child>
                 <child type="end">
                   <object class="GtkButton" id="export_audio_button">
-                    <property name="icon-name">audio-x-generic-symbolic</property>
+                    <property name="icon-name">share-symbolic</property>
                     <property name="tooltip-text" translatable="yes">Export Audio</property>
                     <accessibility>
                       <property name="label" translatable="yes" context="accessibility">Export Audio</property>


### PR DESCRIPTION
Hi @Revisto , I changed the pattern export icon to what @bertob  mentioned "share-sambolic" and also removed all the extra descriptions and export title, exactly what @bertob  mentioned in issue #77 .

# Screen Shots
## new export icon : share-sambolic
<img width="993" height="173" alt="Screenshot From 2025-09-08 09-39-26 (Edit)" src="https://github.com/user-attachments/assets/f6d149a8-a9b7-4191-a17d-9a0fa82cb33f" />

## removing extra notes : 
<img width="1122" height="861" alt="Screenshot From 2025-09-08 09-32-57" src="https://github.com/user-attachments/assets/b93159cb-93e1-4603-ae90-93b97f792eea" />

