### PR TITLE
Fix read-only filesystem error when running as snap

### DIFF
--- a/src/services/drum_part_manager.py
+++ b/src/services/drum_part_manager.py
@@ -41,19 +41,22 @@ DEFAULT_MIDI_NOTES = {
 
 
 class DrumPartManager:
-    def __init__(self, drumkit_dir: str):
-        self.drumkit_dir = drumkit_dir
-        self.custom_dir = os.path.join(drumkit_dir, "config")
-        self.config_file = os.path.join(self.custom_dir, DRUM_PARTS_CONFIG_FILE)
+    def __init__(self, user_data_dir: str, bundled_sounds_dir: str = None):
+        # User-writable directory for config and custom sounds
+        self.user_data_dir = user_data_dir
+        # Read-only directory with bundled default sounds (e.g., in snap)
+        self.bundled_sounds_dir = bundled_sounds_dir or user_data_dir
+        self.config_dir = os.path.join(user_data_dir, "config")
+        self.config_file = os.path.join(self.config_dir, DRUM_PARTS_CONFIG_FILE)
         self._drum_parts: List[DrumPart] = []
         self._ensure_directories()
         self._load_drum_parts()
 
     def _ensure_directories(self):
         try:
-            os.makedirs(self.custom_dir, exist_ok=True)
+            os.makedirs(self.config_dir, exist_ok=True)
         except Exception as e:
-            logging.error(f"Error creating custom directory {self.custom_dir}: {e}")
+            logging.error(f"Error creating config directory {self.config_dir}: {e}")
             raise
 
     def _load_drum_parts(self):
@@ -92,9 +95,9 @@ class DrumPartManager:
             self._save_drum_parts()
 
     def _load_default_parts(self):
-        """Load the default drum parts from the drumkit directory"""
+        """Load the default drum parts from the bundled sounds directory"""
         for name in DEFAULT_DRUM_PARTS:
-            file_path = os.path.join(self.drumkit_dir, f"{name}.wav")
+            file_path = os.path.join(self.bundled_sounds_dir, f"{name}.wav")
             if os.path.exists(file_path):
                 midi_note_id = DEFAULT_MIDI_NOTES.get(name)
                 drum_part = DrumPart.create_default(name, file_path, midi_note_id)

--- a/src/services/sound_service.py
+++ b/src/services/sound_service.py
@@ -26,11 +26,12 @@ from ..config.constants import MIXER_CHANNELS
 
 
 class SoundService(ISoundService):
-    def __init__(self, drumkit_dir: str) -> None:
+    def __init__(self, user_data_dir: str, bundled_sounds_dir: str = None) -> None:
         pygame.init()
         pygame.mixer.set_num_channels(MIXER_CHANNELS)
-        self.drumkit_dir = drumkit_dir
-        self.drum_part_manager = DrumPartManager(drumkit_dir)
+        self.user_data_dir = user_data_dir
+        self.bundled_sounds_dir = bundled_sounds_dir or user_data_dir
+        self.drum_part_manager = DrumPartManager(user_data_dir, self.bundled_sounds_dir)
         self.sounds: Dict[str, pygame.mixer.Sound] = {}
         self._current_volume: float = 1.0
 

--- a/src/window.py
+++ b/src/window.py
@@ -65,10 +65,18 @@ class DrumMachineWindow(Adw.ApplicationWindow):
     def _setup_services(self) -> None:
         """Initialize all services"""
         self.application = self.get_application()
-        drumkit_dir = os.path.join(os.path.dirname(__file__), "..", "data", "drumkit")
+        # Bundled sounds from app install location (read-only in snaps)
+        bundled_sounds_dir = os.path.join(
+            os.path.dirname(__file__), "..", "data", "drumkit"
+        )
+        # User data directory (writable) - uses SNAP_USER_DATA in snaps,
+        # or XDG_DATA_HOME otherwise
+        user_data_dir = os.path.join(
+            GLib.get_user_data_dir(), "drum-machine", "drumkit"
+        )
 
         try:
-            self.sound_service = SoundService(drumkit_dir)
+            self.sound_service = SoundService(user_data_dir, bundled_sounds_dir)
             self.sound_service.load_sounds()
         except Exception as e:
             logging.critical(f"Failed to initialize sound service: {e}")


### PR DESCRIPTION
## Problem

When running as a snap, the app crashes with "Read-only file system" error because it tries to write config and custom sounds to the snap's read-only install location.

## Solution

Separate the bundled sounds directory (read-only) from the user data directory (writable):

- **Bundled sounds**: Read from app install location (`data/drumkit/`)
- **User config/custom sounds**: Write to `$XDG_DATA_HOME/drum-machine/drumkit/` (which maps to `$SNAP_USER_DATA` in snaps)
