### PR TITLE
Mark constants translatable

### DIFF
--- a/io.github.revisto.drum-machine.json
+++ b/io.github.revisto.drum-machine.json
@@ -25,14 +25,16 @@
     "modules" : [
         "python-dependencies.json",
         {
-            "name": "blueprint-compiler",
-            "buildsystem": "meson",
-            "cleanup": ["*"],
-            "sources": [
+            "name" : "blueprint-compiler",
+            "buildsystem" : "meson",
+            "cleanup" : [
+                "*"
+            ],
+            "sources" : [
                 {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/GNOME/blueprint-compiler",
-                    "tag": "0.18.0"
+                    "type" : "git",
+                    "url" : "https://gitlab.gnome.org/GNOME/blueprint-compiler",
+                    "tag" : "0.18.0"
                 }
             ]
         },
@@ -45,7 +47,13 @@
                     "type" : "dir",
                     "path" : "."
                 }
+            ],
+            "config-opts" : [
+                "--libdir=lib"
             ]
         }
-    ]
+    ],
+    "build-options" : {
+        "env" : {        }
+    }
 }

--- a/src/config/constants.py
+++ b/src/config/constants.py
@@ -18,27 +18,32 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from typing import List, Set, Tuple
+from gettext import gettext as _
 
+# Default drum part names shown in the UI
 DEFAULT_DRUM_PARTS: List[str] = [
-    "kick",
-    "kick-2",
-    "kick-3",
-    "snare",
-    "snare-2",
-    "hihat",
-    "hihat-2",
-    "clap",
-    "tom",
-    "crash",
+    _("kick"),
+    _("kick-2"),
+    _("kick-3"),
+    _("snare"),
+    _("snare-2"),
+    _("hihat"),
+    _("hihat-2"),
+    _("clap"),
+    _("tom"),
+    _("crash"),
 ]
+
+# Default rhythm pattern names shown in the UI
 DEFAULT_PATTERNS: List[str] = [
-    "Shoot",
-    "Maybe Rock",
-    "Boom Boom",
-    "Night",
-    "Slow",
-    "Chill",
+    _("Shoot"),
+    _("Maybe Rock"),
+    _("Boom Boom"),
+    _("Night"),
+    _("Slow"),
+    _("Chill"),
 ]
+
 NUM_TOGGLES: int = 16
 GROUP_TOGGLE_COUNT: int = 4
 DEFAULT_BPM: int = 120


### PR DESCRIPTION
# Description
I’ve wrapped the default drum part and rhythm pattern names in gettext (_()) so they can be translated.

# Type of Change
- [x] Addresses [Issue #113](https://github.com/Revisto/drum-machine/issues/113?utm_source=chatgpt.com)
- [x] Prepares the constants for localisation.

# Additional Notes
Please note this is my first ever contribution so hopefully I have done it correctly.